### PR TITLE
Add StringLiteral-Machine

### DIFF
--- a/src/main/java/com/compiler/machines/StringLiteral.java
+++ b/src/main/java/com/compiler/machines/StringLiteral.java
@@ -1,0 +1,38 @@
+package com.compiler.machines;
+
+import com.compiler.TokenIntf;
+
+public class StringLiteral extends com.compiler.StateMachine {
+
+    @Override
+    public void initStateTable() {
+        final com.compiler.State startState = new com.compiler.State("start", false);
+        startState.addTransition('"', "state1");
+        addState(startState);
+
+        final com.compiler.State state1 = new com.compiler.State("state1", false);
+        // Wir haben in der ASCII-Tabelle geschaut und erlauben alle Zeichen von
+        // SPACE (32) bis " (34) und dann von " (34) bis ~ (126).
+        // In diesem Bereich befinden sich alle Buchstaben, Zahlen und Sonderzeichen von ASCII.
+        // Umlaute oder z. B. UTF-8 spezifische Zeichen sind nicht erlaubt!!
+        state1.addTransitionRange(' ', (char) ('"' - 1), "state1");
+        state1.addTransitionRange((char) ('"' + 1), '~', "state1");
+        state1.addTransition('"', "end");
+        addState(state1);
+
+        final com.compiler.State endState = new com.compiler.State("end", true);
+        addState(endState);
+    }
+
+
+    @Override
+    public String getStartState() {
+        return "start";
+    }
+
+
+    @Override
+    public TokenIntf.Type getType() {
+        return TokenIntf.Type.STRING;
+    }
+}

--- a/src/test/java/com/compiler/machnines/StringLiteralTest.java
+++ b/src/test/java/com/compiler/machnines/StringLiteralTest.java
@@ -1,0 +1,31 @@
+package com.compiler.machnines;
+
+import com.MachineTestBase;
+import org.junit.Test;
+
+public class StringLiteralTest extends MachineTestBase {
+
+    private void testWord(final String word, final Boolean expectOk) throws Exception {
+        testWord(new com.compiler.machines.StringLiteral(), word, expectOk);
+    }
+
+    @Test
+    public void testAccept() throws Exception {
+        testWord("\"\"", true);
+        testWord("\"A\"", true);
+        testWord("\"Hallo ich bin ein Test!\"", true);
+        testWord("\"1\"", true);
+        testWord("\"A1a2\"", true);
+    }
+
+
+    @Test
+    public void testNoAccept() throws Exception {
+        testWord("\"BB\"BBAA\"", false);
+        testWord("\"BB\" 12AA\"", false);
+        testWord("B\" 12AA\"", false);
+        testWord("B\"", false);
+        testWord("\"B", false);
+        testWord("A", false);
+    }
+}


### PR DESCRIPTION
Maschine für einen StringLiteral.

Dabei haben wir als erlaube Zeichen in einem String nur die ASCII-Tabelle verwendet. Darunter fallen somit keine Umlaute oder UTF-8 spezifische Sonderzeichen.

Folgende Zeichen sind nach ASCII erlaubt:
SPACE (32) bis " (34) und dann von " (34) bis ~ (126)
