### PR TITLE
Add BitAndOrAST and fix bit-and higher priority than bit-or

### DIFF
--- a/src/main/java/com/compiler/ExpressionEvaluator.java
+++ b/src/main/java/com/compiler/ExpressionEvaluator.java
@@ -23,7 +23,7 @@ public class ExpressionEvaluator implements ExpressionEvaluatorIntf {
             return Integer.valueOf(curToken.m_value);    
         } else if (curToken.m_type == TokenIntf.Type.LPAREN) {
             m_lexer.advance(); // LPAREN
-            int result = getQuestionMarkExpr();
+            final int result = getQuestionMarkExpr();
             m_lexer.expect(TokenIntf.Type.RPAREN);
             return result;
         } else {
@@ -36,14 +36,14 @@ public class ExpressionEvaluator implements ExpressionEvaluatorIntf {
         int result = getParantheseExpr();
         while (m_lexer.lookAhead().m_type == TokenIntf.Type.TDASH) {
             m_lexer.advance();
-            int op = getParantheseExpr();
+            final int op = getParantheseExpr();
             result = (int) Math.pow(result, op);
         }
         return result;
     }
 
     int getUnaryExpr() throws Exception {
-        TokenIntf.Type tokenType = m_lexer.lookAhead().m_type;
+        final TokenIntf.Type tokenType = m_lexer.lookAhead().m_type;
         if (tokenType == TokenIntf.Type.MINUS) {
             m_lexer.advance();
             return -getDashExpr();
@@ -66,11 +66,11 @@ public class ExpressionEvaluator implements ExpressionEvaluatorIntf {
                 m_lexer.lookAhead().m_type == TokenIntf.Type.MUL ||
                         m_lexer.lookAhead().m_type == TokenIntf.Type.DIV
         ) {
-            TokenIntf.Type operator = m_lexer.lookAhead().m_type;
+            final TokenIntf.Type operator = m_lexer.lookAhead().m_type;
 
             m_lexer.advance();
 
-            int operand2 = getUnaryExpr();
+            final int operand2 = getUnaryExpr();
 
 
             if (operator == TokenIntf.Type.MUL) {
@@ -106,19 +106,29 @@ public class ExpressionEvaluator implements ExpressionEvaluatorIntf {
     }
 
     int getBitAndOrExpr() throws Exception {
+        return getBitOr();
+    }
+
+    int getBitAnd() throws Exception {
+        // bitAndExpr: plusMinusExpr (BITAND bitAndExpr)*
+        // ACHTUNG: & hat höhere Priorität, daher haben wir zwei einzelne Funktionen erstellt.
+        // Das sich für die anderen nichts ändert, geben wir hier einfach das bitOr zurück!
         int result = getPlusMinusExpr();
-        while (
-                m_lexer.lookAhead().m_type == TokenIntf.Type.BITAND ||
-                        m_lexer.lookAhead().m_type == TokenIntf.Type.BITOR
-        ) {
-            final TokenIntf.Type tokenType = m_lexer.lookAhead().m_type;
+        while (m_lexer.lookAhead().m_type == TokenIntf.Type.BITAND) {
             m_lexer.advance();
             final int op = getPlusMinusExpr();
-            if (tokenType == TokenIntf.Type.BITAND) {
-                result &= op;
-            } else {
-                result |= op;
-            }
+            result &= op;
+        }
+        return result;
+    }
+
+    int getBitOr() throws Exception {
+        // bitOrExpr: bitAndExpr (BITOR bitOrExpr)*
+        int result = getBitAnd();
+        while (m_lexer.lookAhead().m_type == Type.BITOR) {
+            m_lexer.advance();
+            final int op = getBitAnd();
+            result |= op;
         }
         return result;
     }
@@ -130,9 +140,9 @@ public class ExpressionEvaluator implements ExpressionEvaluatorIntf {
             m_lexer.lookAhead().m_type == TokenIntf.Type.SHIFTRIGHT ||
             m_lexer.lookAhead().m_type == TokenIntf.Type.SHIFTLEFT
         ) {
-            TokenIntf.Type tokenType = m_lexer.lookAhead().m_type;
+            final TokenIntf.Type tokenType = m_lexer.lookAhead().m_type;
             m_lexer.advance(); // getShiftOp()
-            int op = getBitAndOrExpr();
+            final int op = getBitAndOrExpr();
             if (tokenType == TokenIntf.Type.SHIFTRIGHT) {
                 result = result >> op;
             } else {
@@ -152,7 +162,7 @@ public class ExpressionEvaluator implements ExpressionEvaluatorIntf {
                 m_lexer.lookAhead().m_type == Type.GREATER ||
                 m_lexer.lookAhead().m_type == Type.LESS
         ) {
-            TokenIntf.Type tokenType = m_lexer.lookAhead().m_type;
+            final TokenIntf.Type tokenType = m_lexer.lookAhead().m_type;
             m_lexer.advance();
 
             switch (tokenType){
@@ -193,7 +203,7 @@ public class ExpressionEvaluator implements ExpressionEvaluatorIntf {
         int result = getAndExpr();
         while (m_lexer.lookAhead().m_type == TokenIntf.Type.OR) {
             m_lexer.advance(); // getOrOp()
-            int op = getAndExpr();
+            final int op = getAndExpr();
             result = result == 0 && op == 0 ? 0 : 1;
         }
         return result;
@@ -204,7 +214,7 @@ public class ExpressionEvaluator implements ExpressionEvaluatorIntf {
         int result = getCompareExpr();
         while (m_lexer.lookAhead().m_type == TokenIntf.Type.AND) {
             m_lexer.advance(); // getAndOp()
-            int op = getAndExpr();
+            final int op = getAndExpr();
             result = result == 0 || op == 0 ? 0 : 1;
         }
         return result;
@@ -212,17 +222,17 @@ public class ExpressionEvaluator implements ExpressionEvaluatorIntf {
 
     int getQuestionMarkExpr() throws Exception {
         // questionMarkExpr : andOrExpr (QUESTIONMARK questionMarkExpr DOUBLECOLON questionMarkExpr)?
-        int result = getAndOrExpr();
-        boolean predicate = result != 0;
+        final int result = getAndOrExpr();
+        final boolean predicate = result != 0;
         
         if(m_lexer.lookAhead().m_type == TokenIntf.Type.QUESTIONMARK) {
             m_lexer.advance(); // QUESTIONMARK
-            int op1 = getQuestionMarkExpr();
+            final int op1 = getQuestionMarkExpr();
 
             if(m_lexer.lookAhead().m_type != TokenIntf.Type.DOUBLECOLON) throw new Exception("Colon expected in ternary operator");
             
             m_lexer.advance();
-            int op2 = getQuestionMarkExpr();
+            final int op2 = getQuestionMarkExpr();
 
             return predicate ? op1: op2;
         } else {

--- a/src/main/java/com/compiler/ast/ASTBitAndExprNode.java
+++ b/src/main/java/com/compiler/ast/ASTBitAndExprNode.java
@@ -1,0 +1,30 @@
+package com.compiler.ast;
+
+import com.compiler.TokenIntf;
+
+import java.io.OutputStreamWriter;
+
+public class ASTBitAndExprNode extends ASTExprNode {
+
+    ASTExprNode m_operand0;
+    ASTExprNode m_operand1;
+    TokenIntf.Type m_operator;
+
+    public ASTBitAndExprNode(final ASTExprNode operand0, final ASTExprNode operand1, final TokenIntf.Type operator) {
+        m_operand0 = operand0;
+        m_operand1 = operand1;
+        m_operator = operator;
+    }
+
+    public int eval() {
+       final int operand0 = m_operand0.eval();
+       final int operand1 = m_operand1.eval();
+       if (m_operator == TokenIntf.Type.BITAND) {
+          return operand0 & operand1;
+       } else {
+           return operand0 | operand1;
+       }
+    }
+
+    public void print(final OutputStreamWriter outStream, final String indent) throws Exception {}
+}

--- a/src/main/java/com/compiler/ast/ASTBitOrExprNode.java
+++ b/src/main/java/com/compiler/ast/ASTBitOrExprNode.java
@@ -1,0 +1,30 @@
+package com.compiler.ast;
+
+import com.compiler.TokenIntf;
+
+import java.io.OutputStreamWriter;
+
+public class ASTBitOrExprNode extends ASTExprNode {
+
+    ASTExprNode m_operand0;
+    ASTExprNode m_operand1;
+    com.compiler.TokenIntf.Type m_operator;
+
+    public ASTBitOrExprNode(final ASTExprNode operand0, final ASTExprNode operand1, final com.compiler.TokenIntf.Type operator) {
+        m_operand0 = operand0;
+        m_operand1 = operand1;
+        m_operator = operator;
+    }
+
+    public int eval() {
+       final int operand0 = m_operand0.eval();
+       final int operand1 = m_operand1.eval();
+       if (m_operator == TokenIntf.Type.BITAND) {
+          return operand0 & operand1;
+       } else {
+           return operand0 | operand1;
+       }
+    }
+
+    public void print(final OutputStreamWriter outStream, final String indent) throws Exception {}
+}

--- a/src/test/java/com/compiler/TestBitAndOrExpr.java
+++ b/src/test/java/com/compiler/TestBitAndOrExpr.java
@@ -19,5 +19,9 @@ public class TestBitAndOrExpr extends TestExpressionEvaluatorBase {
         // Komplexere Ausdrücke
       assertEquals(4&3|1&5, evalExpression("4&3|1&5"));
       assertEquals(1|2&3|7, evalExpression("1|2&3|7"));
+
+        // Überprüfung, das & eine höhere Priorität als | hat.
+      assertEquals(5 & 4 | 3, evalExpression("5 & 4 | 3"));
+      assertEquals(5 | 4 & 3, evalExpression("5 | 4 & 3"));
     }
 }

--- a/src/test/java/com/compiler/TestBitAndOrExprParser.java
+++ b/src/test/java/com/compiler/TestBitAndOrExprParser.java
@@ -1,0 +1,27 @@
+package com.compiler;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestBitAndOrExprParser extends TestExpressionParserBase {
+
+    @Test
+    public void testBitAndOrExpr() throws Exception {
+        // Check Java Compiler vs. unser Compiler
+        assertEquals(4|1, evalExpression("4|1"));
+        assertEquals(4&1, evalExpression("4&1"));
+
+        // Check Ergebnis vs. unser Compiler
+        assertEquals(5, evalExpression("4|1"));
+        assertEquals(0, evalExpression("4&1"));
+
+        // Komplexere Ausdrücke
+        assertEquals(4&3|1&5, evalExpression("4&3|1&5"));
+        assertEquals(1|2&3|7, evalExpression("1|2&3|7"));
+
+        // Überprüfung, das & eine höhere Priorität als | hat.
+        assertEquals(5 & 4 | 3, evalExpression("5 & 4 | 3"));
+        assertEquals(5 | 4 & 3, evalExpression("5 | 4 & 3"));
+    }
+}


### PR DESCRIPTION
Hier unsere Implementierung für den BitAndOrAST.

Uns ist hierbei jedoch aufgefallen, dass das BITAND und BITOR unterschiedliche Prioritäten besitzen. Hierbei wird zunächst das BITAND und anschließend das BITOR ausgewertet. 

Dies haben wir in diesem PR noch für den Descent Parser nachgeholt, dass zuerst BITAND und anschließend BITOR ausgewertet wird.