### PR TITLE
Add print-Method to ASTBitAnd and ASTBitOr and ASTStmtList

### DIFF
--- a/src/main/java/com/compiler/ast/ASTBitAndExprNode.java
+++ b/src/main/java/com/compiler/ast/ASTBitAndExprNode.java
@@ -22,5 +22,12 @@ public class ASTBitAndExprNode extends ASTExprNode {
        return operand0 & operand1;
     }
 
-    public void print(final OutputStreamWriter outStream, final String indent) throws Exception {}
+    public void print(final OutputStreamWriter outStream, final String indent) throws Exception {
+        outStream.write(indent);
+        outStream.write("BitAndExpression ");
+        outStream.write(m_operator.toString());
+        outStream.write("\n");
+        m_operand0.print(outStream, indent + "  ");
+        m_operand1.print(outStream, indent + "  ");
+    }
 }

--- a/src/main/java/com/compiler/ast/ASTBitOrExprNode.java
+++ b/src/main/java/com/compiler/ast/ASTBitOrExprNode.java
@@ -20,5 +20,12 @@ public class ASTBitOrExprNode extends ASTExprNode {
        return operand0 | operand1;
     }
 
-    public void print(final OutputStreamWriter outStream, final String indent) throws Exception {}
+    public void print(final OutputStreamWriter outStream, final String indent) throws Exception {
+        outStream.write(indent);
+        outStream.write("BitOrExpression ");
+        outStream.write(m_operator.toString());
+        outStream.write("\n");
+        m_operand0.print(outStream, indent + "  ");
+        m_operand1.print(outStream, indent + "  ");
+    }
 }

--- a/src/main/java/com/compiler/ast/ASTStmtListNode.java
+++ b/src/main/java/com/compiler/ast/ASTStmtListNode.java
@@ -21,6 +21,12 @@ public class ASTStmtListNode extends ASTStmtNode {
 
     @Override
     public void print(final OutputStreamWriter outStream, final String indent) throws Exception {
-        
+        this.stmts.forEach(stmt -> {
+            try {
+                stmt.print(outStream, indent);
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 }

--- a/src/main/java/com/compiler/ast/ASTStmtListNode.java
+++ b/src/main/java/com/compiler/ast/ASTStmtListNode.java
@@ -21,9 +21,11 @@ public class ASTStmtListNode extends ASTStmtNode {
 
     @Override
     public void print(final OutputStreamWriter outStream, final String indent) throws Exception {
+        outStream.write("StatementList\n");
         this.stmts.forEach(stmt -> {
             try {
-                stmt.print(outStream, indent);
+                stmt.print(outStream, indent + "  ");
+                outStream.write("\n");
             } catch (final Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/test/java/com/compiler/StmtListParserTest.java
+++ b/src/test/java/com/compiler/StmtListParserTest.java
@@ -1,0 +1,48 @@
+package com.compiler;
+
+import org.junit.Test;
+
+public class StmtListParserTest extends StmtParserTestBase {
+    
+    @Test
+    public void testAndParser() throws Exception {
+        final String program = """
+                {
+                  DECLARE a;
+                  a = 2 & 2;
+                  PRINT a;
+                }
+                """;
+        testParser(program, "2\n");
+    }
+
+
+    @Test
+    public void testOrParser() throws Exception {
+        final String program = """
+                {
+                  DECLARE a;
+                  a = 2 | 1;
+                  PRINT a;
+                }
+                """;
+        testParser(program, "3\n");
+    }
+
+
+    @Test
+    public void testAndOrParser() throws Exception {
+        final String program = """
+                {
+                  DECLARE a;
+                  DECLARE b;
+                  DECLARE c;
+                  a = 2 & 2;
+                  b = 1 | 2;
+                  c = a & b;
+                  PRINT c;
+                }
+                """;
+        testParser(program, "2\n");
+    }
+}


### PR DESCRIPTION
Wir haben die Print-Methoden für den ASTBitAnd und ASTBitOr implementiert.

In der Klasse ASTStmtListNode haben wir einfach wie bei der execute-Methode() die print-Methode von den AST-Klassen in der Liste aufgerufen. Ist das richtig so oder müssen wir da eine andere Logik einbauen?

Zudem habe wir auch noch keine Tests geschrieben, da auch der ExpressionParser Fehler beinhaltet. Sollen wir diese Tests noch nachtragen?

LG Marco und Tim